### PR TITLE
fix for spurious uptime when the stream is offline

### DIFF
--- a/kraken.go
+++ b/kraken.go
@@ -35,12 +35,12 @@ func roundToSeconds(d time.Duration) time.Duration {
 
 func getUptime(channel string) string {
 	var data struct {
-		Stream struct {
+		Stream *struct {
 			CreatedAt time.Time `json:"created_at"`
 		}
 	}
 	err := kraken(&data, "streams", channel)
-	if err != nil {
+	if err != nil || data.Stream == nil {
 		log.Printf("getUptime=%v", err)
 		return fmt.Sprintf("%s is not online", channel)
 	}


### PR DESCRIPTION
Fixes the spurious uptime when the stream is offline:
```
<delta__vee> !uptime
<@kaet> ​-2562047h47m16s
```
