### PR TITLE
support removing quotes: command `!removequote` with quote number

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -69,11 +69,12 @@ func init() {
 	cmds.cmds["help"] = &command{cmdHelp, false}
 	cmds.cmds["uptime"] = &command{func(_ string) string { return getUptime(CHANNEL) }, false}
 	cmds.cmds["game"] = &command{func(_ string) string { return getGame(CHANNEL, true) }, false}
-	cmds.cmds["quote"] = &command{func(q string) string { return quotes.Random(q) }, false}
+	cmds.cmds["quote"] = &command{cmdGetQuote, false}
 	cmds.cmds["sourcecode"] = &command{func(q string) string { return "Contribute to kaet's source code at github.com/Fugiman/kaet VoHiYo" }, false}
 
 	// Mod commands
 	cmds.cmds["addquote"] = &command{cmdAddQuote, true}
+	cmds.cmds["removequote"] = &command{cmdRemoveQuote, true}
 	cmds.cmds["addcommand"] = &command{cmdAddCommand, true}
 	cmds.cmds["removecommand"] = &command{cmdRemoveCommand, true}
 
@@ -131,6 +132,32 @@ func cmdAddQuote(quote string) string {
 	}
 	quotes.Append(fmt.Sprintf("%s [Playing %s - %s]", quote, g, t.Format(time.RFC822)))
 	return ""
+}
+
+func cmdRemoveQuote(quoteNum string) string {
+	if strings.HasPrefix(quoteNum, "#") {
+		quoteNum = quoteNum[1:]
+	}
+	// cmdAddQuote relies on continuous numbering, so blank the quotes instead of removing them
+	found := quotes.Blank(quoteNum)
+	if found {
+		return fmt.Sprintf("Removed #%s", quoteNum)
+	} else {
+		return ""
+	}
+}
+
+func cmdGetQuote(query string) string {
+	if strings.HasPrefix(query, "#") {
+		quote, found := quotes.Get(query[1:])
+		if found && quote != "" {
+			return quote
+		} else {
+			return "Not found"
+		}
+	} else {
+		return quotes.Random(query)
+	}
 }
 
 func cmdAddCommand(data string) string {


### PR DESCRIPTION
The `!quote` output now has a quote number at the end (when getting a random quote / searching):
```
<delta__vee> !quote
<@ee__vee> ​this is some quote [Playing some game - 11 Jan 17 03:10 PST] #4
<delta__vee> !quote test
<@ee__vee> ​here is a test quote [Playing some game - 11 Jan 17 03:05 PST] #0
```

Mods can remove a specific quote by number with `!removequote` and it will be removed, and no longer appear in `!quote` results. The `#` in front of the number is optional.

```
<delta__vee> !removequote 1
<@ee__vee> ​Removed #1
<delta__vee> !removequote #5
<@ee__vee> ​Removed #5
```

You can get the quote for a specific number (a way to double-check):
```
<delta__vee> !quote #4
<@ee__vee> ​this is some quote [Playing some game - 11 Jan 17 03:10 PST]
```

Removing a quote doesn't affect the numbering of other quotes, to support the behaviour of `!addquote`:
```
<delta__vee> !addquote I am a quote
<delta__vee> !addquote I am another quote
<delta__vee> !quote #5
<@ee__vee> ​I am a quote [Playing some game - 11 Jan 17 03:20 PST]
<delta__vee> !quote #6
<@ee__vee> ​I am another quote [Playing some game - 11 Jan 17 03:20 PST]
<delta__vee> !removequote #5
<@ee__vee> ​Removed #5
<delta__vee> !quote #5
<@ee__vee> ​Not found
<delta__vee> !addquote I am yet another quote
<delta__vee> !quote #5
<@ee__vee> ​Not found
<delta__vee> !quote #6
<@ee__vee> ​I am another quote [Playing some game - 11 Jan 17 03:20 PST]
<delta__vee> !quote #7
<@ee__vee> ​I am yet another quote [Playing some game - 11 Jan 17 03:21 PST]
```